### PR TITLE
chainer also needs scipy

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
 	      <pre><code>pip install chainer</code></pre>
 	    </p>
 	    <p>
-	      Run the MNIST example (it requires scikit-learn):<br>
+	      Run the MNIST example (it requires scikit-learn and scipy):<br>
 	      <pre><code>git clone https://github.com/pfnet/chainer.git
 python chainer/examples/mnist/train_mnist.py</code></pre>
 	    </p>


### PR DESCRIPTION
When I `pip install scikit-learn` and tried to run chainer (looking at this index page,) chainer complained for scipy missing.
It would be kind for future readers, to mention the dependency on `scipy` here.
